### PR TITLE
fix(W2-398): relocate and resize scroll top button on mobile

### DIFF
--- a/src/common/components/ScrollTopButton/index.tsx
+++ b/src/common/components/ScrollTopButton/index.tsx
@@ -21,18 +21,19 @@ const ScrollTopButton = () => {
       <Button
         onClick={scrollToTop}
         position="fixed"
-        bottom="32px"
-        right="32px"
+        bottom={{base: '20px', md: '32px'}}
+        right={{ base: '50%', md: '32px' }}
+        transform={{ base: 'translateX(50%)', md: 'none' }}
         zIndex={1000}
         colorScheme="red"
         borderRadius="full"
         boxShadow="lg"
-        w="50px"
-        h="50px"
+        w= {{base: '20px', md: '50px'}}
+        h={{base: '40px', md: '50px'}}
         aria-label="Scroll to top"
         p="0"
       >
-        <ChevronUpIcon boxSize={6} />
+        <ChevronUpIcon boxSize={{base: 4, md: 6}} />
       </Button>
     )
   );


### PR DESCRIPTION
## Checklist (check all applicable) (*)
- [x] Self Review
- [x] Self Test
- [x] Upload Evidence
- [x] Optimization
- [x] Documentation Update

## Description
- Relocate and resize scroll top button on mobile
## Related Tickets & Documents (*)
- Related Issue #398 
## Evidence (*)
- ![image](https://github.com/user-attachments/assets/966d1b71-0b4f-4be7-9d6d-b22851081000)