### PR TITLE
feat(W2-402): fix dark mode text in login page

### DIFF
--- a/src/features/auth/__test__/__snapshots__/LoginForm.test.tsx.snap
+++ b/src/features/auth/__test__/__snapshots__/LoginForm.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`Login Page Check Display form Log in 1`] = `
           </div>
         </form>
         <button
-          class="chakra-button css-1q34lwh"
+          class="chakra-button css-1kfhv4b"
           type="button"
         >
           <img

--- a/src/features/auth/pages/Login.tsx
+++ b/src/features/auth/pages/Login.tsx
@@ -29,6 +29,12 @@ const initialLoginParams: LoginParams = {
 
 const Login = () => {
   const bg = useColorModeValue(ColorThemeMode.LIGHT, ColorThemeMode.DARK);
+
+  // Mezon button styles
+  const mezonBtnColor = useColorModeValue('white', 'stone.900');
+  const mezonBtnBackground = useColorModeValue('stone.900', 'stone.100');
+  const mezonBtnHoverBackground = useColorModeValue('stone.700', 'stone.300');
+
   const redirectURL = getItem(LocalStorageKeys.prevURL)
     ? getItem(LocalStorageKeys.prevURL)
     : '/';
@@ -163,13 +169,20 @@ const Login = () => {
               </VStack>
             </form>
           )}
+
+          {/* Mezon Login Button */}
           <Button
             isLoading={isMezonLoginLoading}
             onClick={handleLoginWithMezon}
             w="full"
             h="50px"
             colorScheme="white"
-            background="black"
+            background={mezonBtnBackground}
+            color={mezonBtnColor}
+            _hover={{
+              background: mezonBtnHoverBackground,
+            }}
+            transition="background 0.3s"
             flexDirection="row"
             gap={4}
           >


### PR DESCRIPTION
## Checklist (check all applicable) (*)
- [x] Self Review
- [x] Self Test
- [x] Upload Evidence
- [ ] Optimization
- [ ] Documentation Update

## Description
- Changed background & text of mezon login button.

## Related Tickets & Documents (*)
- Related Issue #402 

## Evidence (*)
[<!--
Please make sure to have evidence when ticket done
-->]()
https://www.awesomescreenshot.com/video/43221382?key=5f2fb59dbb1d036c697efb504d1cd461

- Dark mode (Edge):
<img width="1919" height="1015" alt="image" src="https://github.com/user-attachments/assets/1d7dd73a-feaf-44ba-8766-479e5d1882d7" />

- Light mode (Edge):
<img width="1919" height="1008" alt="image" src="https://github.com/user-attachments/assets/c807021e-251e-416f-a23e-8fd7bb1d6972" />

- Light mode (Chrome):
<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/1cf02bc8-d6f2-4945-8e90-f5c4b5839e98" />
